### PR TITLE
Rework archives into annual collections with month sub-pages

### DIFF
--- a/plugins/archive_data.py
+++ b/plugins/archive_data.py
@@ -2,29 +2,55 @@
 Archive Data Generator Plugin
 Computes archive data once during site generation instead of on every page render
 """
-from collections import defaultdict
 from pelican import signals
 
 
 def compute_archives(generator):
     """
-    Compute archives data from all articles and add to context
-
-    This runs once during generation and makes ARCHIVES_DATA available
-    to all templates, eliminating the need to recompute on every page.
+    Reindex Pelican's already-computed period_archives (year/month groupings)
+    into structures the theme can use without any per-page-render work:
+      - ARCHIVE_YEARS: dict keyed by int year -> {year, url, count, months}
+        (O(1) lookup for a year page's month links)
+      - ARCHIVE_YEARS_LIST: same values, sorted descending, for the flat
+        archives.html year index
+      - CURRENT_ARCHIVE_YEAR: the latest year that has >=1 article, used by
+        the sidebar instead of the calendar year so it can never point at an
+        empty year
     """
-    archives = defaultdict(lambda: {'name': '', 'count': 0})
+    year_entries = generator.period_archives.get('year', [])
+    month_entries = generator.period_archives.get('month', [])
 
-    for article in generator.articles:
-        year_month = article.date.strftime('%Y/%m')
-        month_name = article.date.strftime('%B %Y')
-        archives[year_month]['name'] = month_name
-        archives[year_month]['count'] += 1
+    months_by_year = {}
+    for month in month_entries:
+        year = month['period_num'][0]
+        months_by_year.setdefault(year, []).append({
+            'num': month['period_num'][1],
+            'name': month['period'][1],
+            'url': month['url'],
+            'count': len(month['articles']),
+        })
 
-    # Sort by year/month descending and convert to list of tuples
-    generator.context['ARCHIVES_DATA'] = sorted(
-        [(k, v) for k, v in archives.items()],
-        reverse=True
+    archive_years = {}
+    for year_entry in year_entries:
+        year = year_entry['period_num'][0]
+        months = sorted(
+            months_by_year.get(year, []), key=lambda m: m['num'], reverse=True
+        )
+        archive_years[year] = {
+            'year': year,
+            'url': year_entry['url'],
+            'count': len(year_entry['articles']),
+            'months': months,
+        }
+
+    archive_years_list = sorted(
+        archive_years.values(), key=lambda y: y['year'], reverse=True
+    )
+
+    generator.context['ARCHIVE_YEARS'] = archive_years
+    generator.context['ARCHIVE_YEARS_LIST'] = archive_years_list
+    generator.context['CURRENT_ARCHIVE_YEAR'] = (
+        archive_years_list[0]['year'] if archive_years_list else None
     )
 
 


### PR DESCRIPTION
## Summary

Rework the site's archives so `/archives.html`
becomes a year index, year pages (`/YYYY/`) link out to their month pages
instead of dumping every article, month pages (`/YYYY/MM/`) keep their
current behavior, and the sidebar (rendered on every page) narrows to just
the current year's months — all computed once per build rather than
grouped/filtered in Jinja on every render.

Plan: `/Users/crossjam/.claude/plans/read-the-templates-for-zazzy-finch.md`
(local, not committed).

Confirmed decisions baked into the design:
- "Current year" for the sidebar = the latest year with an actual article,
  not the calendar year, so the sidebar can never render empty.
- `/archives.html` becomes a pure year index; no separate full flat listing
  is preserved elsewhere.
- Theme template edits land in the separate `pelican-svbhack` submodule
  repo on its `crossjam/mpr` branch, not in this repo.

## Status — all complete

- [x] Precompute `ARCHIVE_YEARS`/`ARCHIVE_YEARS_LIST`/
      `CURRENT_ARCHIVE_YEAR` in `plugins/archive_data.py`, reusing Pelican's
      already-grouped `generator.period_archives` instead of a second
      per-article scan. *(this repo, commit a6c5438)*
- [x] Split `period_archives.html` into year vs month branches.
      *(submodule `pelican-svbhack`, branch `crossjam/mpr`, commit `a7b0e86`;
      pointer bumped here at `3eacd1b`)*
- [x] Turn `archives.html` into a year index.
      *(submodule commit `df9429e`; pointer bumped here at `d6164c8`)*
- [x] Narrow `archives_sidebar.html` to current year only.
      *(submodule commit `0839338`; pointer bumped here at `c218879`)*
- [x] Hide the annual archives listing on mobile viewports
      (`.archive-module` hidden below 512px).
      *(submodule commit `a324273`; pointer bumped here at `9073737`)*
- [x] Verified the full rework end-to-end: `poe html` dev build,
      `poe publish` production build + pagefind indexing, dense year (2012,
      421 posts across 12 months), sparse year (2019, 3 months), sidebar
      identical across every page type, `ARCHIVES_DATA` fully retired (zero
      remaining references), and a synthetic zero-posts-this-year test
      (moved all 50 2026-dated articles aside, confirmed sidebar/archives.html
      fall back cleanly to 2025 with no empty state, then restored them).

All five commits (`a6c5438`..`9073737`) are on this branch; the four
template/CSS commits in the theme submodule are pushed to `crossjam/mpr`
on `pelican-svbhack`.

## Follow-up: sidebar tweaks

Requested during review — the sidebar's current-year month list now also
links out to every other year, and the "All years »" link is right-aligned:

- **Past-years links** — below the current year's months, list every other
  year from `ARCHIVE_YEARS_LIST` (excluding `CURRENT_ARCHIVE_YEAR`) linking
  to its year page. *(submodule commit `6c6caf3`; pointer bumped here at
  `53f1f04`)*
- **Right-align "All years »"** — added `.archive-all-years` styling.
  *(submodule commit `e73ff71`; pointer bumped here at `bf2a6d3`)*
- **Fix right-align not applying** — the new class lost to the theme's
  `aside div#user_meta p { text-align: center; }` rule (in the
  `min-width: 512px` media query) because `.archive-module` reuses
  `id="user_meta"`; the id gave that rule higher specificity. Fixed by
  scoping the new rule as `#user_meta .archive-all-years` to match.
  *(submodule commit `b261748`; pointer bumped here at `afc867e`)*

## Test plan

- [x] `poe html` — full dev build succeeds (1963 articles, 0 errors)
- [x] `poe publish` — production build (drafts hidden, real `SITEURL`,
      `RELATIVE_URLS` off) + pagefind indexing succeeds, 2262 pages indexed
- [x] `output/archives.html` lists all 19 years (2008–2026) descending,
      correctly linked and counted
- [x] Year page (`output/2012/index.html`): "Yearly Archives: 2012 | 421
      posts", 12 month links summing to 421
- [x] Month page (`output/2012/06/index.html`): unchanged article listing,
      corrected "Monthly Archives: June 2012 | 34 posts" header
- [x] Sparse year (`output/2019/index.html`): shows only its 3 populated
      months
- [x] Sidebar shows the identical current-year month list across the home
      page, `archives.html`, a year page, a month page, and multiple 2008
      article pages
- [x] `grep -rn ARCHIVES_DATA` across the repo returns zero hits
- [x] Synthetic zero-posts-this-year edge case: sidebar/archives.html fall
      back to 2025 gracefully when 2026 has no articles yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

